### PR TITLE
Fixed SortByDescending not working on cosmos

### DIFF
--- a/src/dal/Jalasoft.TeamUp.Projects.DAL/ProjectsMongoDbRepository.cs
+++ b/src/dal/Jalasoft.TeamUp.Projects.DAL/ProjectsMongoDbRepository.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Jalasoft.TeamUp.Projects.DAL.Interfaces;
     using Jalasoft.TeamUp.Projects.Models;
     using MongoDB.Bson;
@@ -30,7 +31,7 @@
 
         public IEnumerable<Project> GetAll()
         {
-            return collection.Find(new BsonDocument()).SortByDescending(project => project.CreationDate).ToEnumerable<Project>();
+            return collection.Find(new BsonDocument()).ToEnumerable<Project>().OrderByDescending(x => x.CreationDate);
         }
 
         public Project GetById(Guid id)


### PR DESCRIPTION
[AB#482](https://dev.azure.com/funjaladev/7867a1c5-5ac7-4c7f-baff-87d740bf4fc1/_workitems/edit/482)

Refactored GetAll function to use Linq for sorting the projects, given that SortByDescending from Mongo Driver was not compatible with CosmosDB
